### PR TITLE
Add support for rsync storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Cache Buildkite Plugin
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to restore and save 
-directories by cache keys. For example, use the checksum of a `.resolved` or `.lock` file 
-to restore/save built dependencies between independent builds, not just jobs. 
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to restore and save
+directories by cache keys. For example, use the checksum of a `.resolved` or `.lock` file
+to restore/save built dependencies between independent builds, not just jobs.
 
 ## Restore & Save Caches
 
@@ -18,21 +18,39 @@ steps:
 
 ## Cache Key Templates
 
-The cache key is a string, which support a crude template system. Currently `checksum` is 
+The cache key is a string, which support a crude template system. Currently `checksum` is
 the only command supported for now. It can be used as in the example above. In this case
-the cache key will be determined by executing a _checksum_ (actually `shasum`) on the 
+the cache key will be determined by executing a _checksum_ (actually `shasum`) on the
 `Podfile.lock` file, prepended with `v1-cache-`.
 
 ## S3 Storage
 
-This plugin uses AWS S3 sync to cache the paths into a bucket as defined by environment 
-variables defined in your agent. 
+This plugin uses AWS S3 sync to cache the paths into a bucket as defined by environment
+variables defined in your agent.
 
 ```bash
 export BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME="my-unique-s3-bucket-name"
 export BUILDKITE_PLUGIN_CACHE_S3_PROFILE="my-s3-profile"
 ```
 
-The paths are synced using Amazon S3 into your bucket using a structure of 
-`organization-slug/pipeline-slug/cache_key`, as determined by the Buildkite environment 
+The paths are synced using Amazon S3 into your bucket using a structure of
+`organization-slug/pipeline-slug/cache_key`, as determined by the Buildkite environment
 variables.
+
+## Rsync Storage
+
+You can also use rsync to store your files using the ``rsync_storage`` config parameter.
+If this is set it will be used as the destination parameter of a ``rsync -az`` command.
+
+```yml
+steps:
+  - plugins:
+    - danthorpe/cache#v1.0.0:
+		rsync_storage: '/tmp/buildkite-cache'
+        cache_key: "v1-cache-{{ checksum 'Podfile.lock' }}"
+        paths: [ "Pods/", "Rome/" ]
+```
+
+The paths are synced using `rsync_storage/cache_key/path`. This is useful for maintaining a local
+cache directory, even though this cache is not shared between servers, it can be reused by different
+agents/builds.

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -20,30 +20,43 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
     cache_key=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
   fi
 
-  bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
-  
   paths=()
-  
+
   if [[ -n "${BUILDKITE_PLUGIN_CACHE_PATHS:-}" ]] ; then
     paths+=("$BUILDKITE_PLUGIN_CACHE_PATHS")
   fi
-  
+
   while IFS='=' read -r path _ ; do
     if [[ $path =~ ^(BUILDKITE_PLUGIN_CACHE_PATHS_[0-9]+) ]] ; then
       paths+=("${!path}")
     fi
   done < <(env | sort)
-  
-  if [ "${#paths[@]}" -eq 1 ]; then
 
-    echo "--- :aws: :amazon-s3: sync ${paths[*]}"
-    aws s3 sync "${paths[*]}" "s3://${bucket}/${paths[*]}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete    
+  if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
+      mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
+  else
+      bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
+  fi
+
+  if [ "${#paths[@]}" -eq 1 ]; then
+      if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
+	  mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${paths[*]}"
+	  rsync -a --delete "${paths[*]}/" "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${paths[*]}/"
+      else
+	  echo "--- :aws: :amazon-s3: sync ${paths[*]}"
+	  aws s3 sync "${paths[*]}" "s3://${bucket}/${paths[*]}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete
+      fi
 
   elif [ "${#paths[@]}" -gt 1 ]; then
     for path in "${paths[@]}"
-      do
-        echo "--- :aws: :amazon-s3: sync ${path}"
-        aws s3 sync "${path}" "s3://${bucket}/${path}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete
-      done
-  fi  
+    do
+	if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
+	    mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${path}"
+	    rsync -a --delete "${path}/" "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${path}/"
+	else
+            echo "--- :aws: :amazon-s3: sync ${path}"
+            aws s3 sync "${path}" "s3://${bucket}/${path}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete
+	fi
+    done
+  fi
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -20,10 +20,15 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
     cache_key=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
   fi
 
-  echo ":aws: :amazon-s3: sync ${cache_key}"
-  
-  bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
-  
-  aws s3 sync "s3://${bucket}/" . --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}"
-    
+  if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
+      mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/"
+      rsync -a "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/" .
+  else
+      echo ":aws: :amazon-s3: sync ${cache_key}"
+
+      bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
+
+      aws s3 sync "s3://${bucket}/" . --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}"
+  fi
+
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,11 +5,13 @@ requirements:
   - aws
 configuration:
   properties:
+    rsync_storage:
+      type: string
     cache_key:
-        type: string
+      type: string
     paths:
-        type: [ string, array ]
+      type: [ string, array ]
     env:
       type: [ string, array ]
-      minimum: 2    
+      minimum: 2
   additionalProperties: false


### PR DESCRIPTION
I was trying to use this plugin for storing node_modules as cache. This was suboptimal as node_modules usually contains a several small files, that made the use of cache worse than calling a ``yarn install`` in every build. I modified the plugin so you can use rsync to store cache locally, this way, the cache can be shared between agents in the same server, and also between builds.