### PR TITLE
[FIX] Switch to sha1sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ steps:
 
 The cache key is a string, which support a crude template system. Currently `checksum` is
 the only command supported for now. It can be used as in the example above. In this case
-the cache key will be determined by executing a _checksum_ (actually `shasum`) on the
+the cache key will be determined by executing a _checksum_ (actually `sha1sum`) on the
 `Podfile.lock` file, prepended with `v1-cache-`.
 
 ## S3 Storage

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -13,7 +13,7 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
 
   if [[ $template_value == *"checksum"* ]]; then
     checksum_argument=$(echo "$template_value" | sed -e 's/checksum*//')
-    function=${template_value/"checksum"/"shasum"}
+    function=${template_value/"checksum"/"sha1sum"}
     result=$($function | tr -d "$checksum_argument")
     cache_key="$cache_key_prefix$result"
   else

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2001
-set -euo pipefail
+set -eo pipefail
 
 if [[ "${BUILDKITE_PLUGIN_CACHE_DEBUG:-false}" =~ (true|on|1) ]] ; then
   set -x

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,7 +13,7 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
 
   if [[ $template_value == *"checksum"* ]]; then
     checksum_argument=$(echo "$template_value" | sed -e 's/checksum*//')
-    function=${template_value/"checksum"/"shasum"}
+    function=${template_value/"checksum"/"sha1sum"}
     result=$($function | tr -d "$checksum_argument")
     cache_key="$cache_key_prefix$result"
   else


### PR DESCRIPTION
Hey @danthorpe 

Not sure if this will break your builds but I found the default AMI used by Buildkite's Cloudformation stack doesn't have the `shasum` binary.

AMI details:
AMI: ami-0a6ff93f1da8f8f0b (ap-southeast-2)
Name: buildkite-stack-2019-11-04T23-01-18Z-ap-southeast-2
Description: Buildkite Elastic Stack (Amazon Linux 2 LTS w/ docker)

I switched over to `sha1sum` instead and it appears to have worked