### PR TITLE
Refactor to compress to tar.gz before uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Cache Buildkite Plugin
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to restore and save 
-directories by cache keys. For example, use the checksum of a `.resolved` or `.lock` file 
-to restore/save built dependencies between independent builds, not just jobs. 
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to restore and save
+directories by cache keys. For example, use the checksum of a `.resolved` or `.lock` file
+to restore/save built dependencies between independent builds, not just jobs.
 
 ## Restore & Save Caches
 
@@ -18,21 +18,21 @@ steps:
 
 ## Cache Key Templates
 
-The cache key is a string, which support a crude template system. Currently `checksum` is 
+The cache key is a string, which support a crude template system. Currently `checksum` is
 the only command supported for now. It can be used as in the example above. In this case
-the cache key will be determined by executing a _checksum_ (actually `shasum`) on the 
+the cache key will be determined by executing a _checksum_ (actually `shasum`) on the
 `Podfile.lock` file, prepended with `v1-cache-`.
 
 ## S3 Storage
 
-This plugin uses AWS S3 sync to cache the paths into a bucket as defined by environment 
-variables defined in your agent. 
+This plugin uses AWS S3 sync to cache the paths into a bucket as defined by environment
+variables defined in your agent.
 
 ```bash
 export BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME="my-unique-s3-bucket-name"
 export BUILDKITE_PLUGIN_CACHE_S3_PROFILE="my-s3-profile"
 ```
 
-The paths are synced using Amazon S3 into your bucket using a structure of 
-`organization-slug/pipeline-slug/cache_key`, as determined by the Buildkite environment 
+The paths are copied using Amazon S3 into your bucket using a structure of
+`organization-slug/pipeline-slug/cache_key/cache.tar.gz`, as determined by the Buildkite environment
 variables.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Cache Buildkite Plugin
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to restore and save
-directories by cache keys. For example, use the checksum of a `.resolved` or `.lock` file
-to restore/save built dependencies between independent builds, not just jobs.
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to restore and save 
+directories by cache keys. For example, use the checksum of a `.resolved` or `.lock` file 
+to restore/save built dependencies between independent builds, not just jobs. 
 
 ## Restore & Save Caches
 
@@ -18,39 +18,21 @@ steps:
 
 ## Cache Key Templates
 
-The cache key is a string, which support a crude template system. Currently `checksum` is
+The cache key is a string, which support a crude template system. Currently `checksum` is 
 the only command supported for now. It can be used as in the example above. In this case
-the cache key will be determined by executing a _checksum_ (actually `shasum`) on the
+the cache key will be determined by executing a _checksum_ (actually `shasum`) on the 
 `Podfile.lock` file, prepended with `v1-cache-`.
 
 ## S3 Storage
 
-This plugin uses AWS S3 sync to cache the paths into a bucket as defined by environment
-variables defined in your agent.
+This plugin uses AWS S3 sync to cache the paths into a bucket as defined by environment 
+variables defined in your agent. 
 
 ```bash
 export BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME="my-unique-s3-bucket-name"
 export BUILDKITE_PLUGIN_CACHE_S3_PROFILE="my-s3-profile"
 ```
 
-The paths are synced using Amazon S3 into your bucket using a structure of
-`organization-slug/pipeline-slug/cache_key`, as determined by the Buildkite environment
+The paths are synced using Amazon S3 into your bucket using a structure of 
+`organization-slug/pipeline-slug/cache_key`, as determined by the Buildkite environment 
 variables.
-
-## Rsync Storage
-
-You can also use rsync to store your files using the ``rsync_storage`` config parameter.
-If this is set it will be used as the destination parameter of a ``rsync -az`` command.
-
-```yml
-steps:
-  - plugins:
-    - danthorpe/cache#v1.0.0:
-		rsync_storage: '/tmp/buildkite-cache'
-        cache_key: "v1-cache-{{ checksum 'Podfile.lock' }}"
-        paths: [ "Pods/", "Rome/" ]
-```
-
-The paths are synced using `rsync_storage/cache_key/path`. This is useful for maintaining a local
-cache directory, even though this cache is not shared between servers, it can be reused by different
-agents/builds.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,12 @@ services:
   tests:
     image: buildkite/plugin-tester
     volumes:
-      - ".:/plugin"
+    - ".:/plugin"
+  shellcheck:
+    image: koalaman/shellcheck:v0.7.0
+    volumes:
+    - ".:/mnt"
+    command:
+    - ./lib/shared.bash
+    - ./hooks/pre-command
+    - ./hooks/post-command

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,49 +1,34 @@
 #!/bin/bash
-# shellcheck disable=SC2001
 set -euo pipefail
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-if [[ "${BUILDKITE_PLUGIN_CACHE_DEBUG:-false}" =~ (true|on|1) ]] ; then
-  set -x
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
+if [[ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]]; then
+  echo "Command failed, not uploading cache"
+  exit 0
 fi
 
-if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
+cache_key=$(get_cache_key)
+bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/$cache_key"
 
-  cache_key_prefix=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/{.*//')
-  template_value=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/^[^\{{]*[^A-Za-z]*//' -e 's/.}}.*$//' | tr -d \' | tr -d \")
-
-  if [[ $template_value == *"checksum"* ]]; then
-    checksum_argument=$(echo "$template_value" | sed -e 's/checksum*//')
-    function=${template_value/"checksum"/"shasum"}
-    result=$($function | tr -d "$checksum_argument")
-    cache_key="$cache_key_prefix$result"
-  else
-    cache_key=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
+paths=()
+while IFS='=' read -r path _ ; do
+  if [[ $path =~ ^(BUILDKITE_PLUGIN_CACHE_PATHS_[0-9]+) ]] ; then
+    paths+=("${!path}")
   fi
+done < <(env | sort | grep BUILDKITE_PLUGIN_CACHE_PATHS_)
 
-  bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
-  
-  paths=()
-  
-  if [[ -n "${BUILDKITE_PLUGIN_CACHE_PATHS:-}" ]] ; then
-    paths+=("$BUILDKITE_PLUGIN_CACHE_PATHS")
-  fi
-  
-  while IFS='=' read -r path _ ; do
-    if [[ $path =~ ^(BUILDKITE_PLUGIN_CACHE_PATHS_[0-9]+) ]] ; then
-      paths+=("${!path}")
-    fi
-  done < <(env | sort)
-  
-  if [ "${#paths[@]}" -eq 1 ]; then
-
-    echo "--- :aws: :amazon-s3: sync ${paths[*]}"
-    aws s3 sync "${paths[*]}" "s3://${bucket}/${paths[*]}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete    
-
-  elif [ "${#paths[@]}" -gt 1 ]; then
-    for path in "${paths[@]}"
-      do
-        echo "--- :aws: :amazon-s3: sync ${path}"
-        aws s3 sync "${path}" "s3://${bucket}/${path}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete
-      done
-  fi  
+tmpdir=$(mktemp -d)
+if [[ "${BUILDKITE_PLUGIN_CACHE_RESTORED:-}" == *":$cache_key:"* ]]; then
+  echo "Not uploading new cache - it was restored"
+  exit 0
 fi
+
+echo "Compressing cache for $cache_key"
+tar -czf "$tmpdir/cache.tar.gz" "${paths[@]}"
+
+echo "Saving cache $cache_key"
+aws s3 cp "$tmpdir/cache.tar.gz" "s3://${bucket}/cache.tar.gz"
+rm -rf "$tmpdir"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -20,43 +20,30 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
     cache_key=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
   fi
 
+  bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
+  
   paths=()
-
+  
   if [[ -n "${BUILDKITE_PLUGIN_CACHE_PATHS:-}" ]] ; then
     paths+=("$BUILDKITE_PLUGIN_CACHE_PATHS")
   fi
-
+  
   while IFS='=' read -r path _ ; do
     if [[ $path =~ ^(BUILDKITE_PLUGIN_CACHE_PATHS_[0-9]+) ]] ; then
       paths+=("${!path}")
     fi
   done < <(env | sort)
-
-  if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
-      mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
-  else
-      bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
-  fi
-
+  
   if [ "${#paths[@]}" -eq 1 ]; then
-      if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
-	  mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${paths[*]}"
-	  rsync -a --delete "${paths[*]}/" "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${paths[*]}/"
-      else
-	  echo "--- :aws: :amazon-s3: sync ${paths[*]}"
-	  aws s3 sync "${paths[*]}" "s3://${bucket}/${paths[*]}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete
-      fi
+
+    echo "--- :aws: :amazon-s3: sync ${paths[*]}"
+    aws s3 sync "${paths[*]}" "s3://${bucket}/${paths[*]}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete    
 
   elif [ "${#paths[@]}" -gt 1 ]; then
     for path in "${paths[@]}"
-    do
-	if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
-	    mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${path}"
-	    rsync -a --delete "${path}/" "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/${path}/"
-	else
-            echo "--- :aws: :amazon-s3: sync ${path}"
-            aws s3 sync "${path}" "s3://${bucket}/${path}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete
-	fi
-    done
-  fi
+      do
+        echo "--- :aws: :amazon-s3: sync ${path}"
+        aws s3 sync "${path}" "s3://${bucket}/${path}/" --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}" --delete
+      done
+  fi  
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -20,15 +20,10 @@ if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
     cache_key=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
   fi
 
-  if [[ -n "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}" ]] ; then
-      mkdir -p "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/"
-      rsync -a "${BUILDKITE_PLUGIN_CACHE_RSYNC_STORAGE}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}/" .
-  else
-      echo ":aws: :amazon-s3: sync ${cache_key}"
-
-      bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
-
-      aws s3 sync "s3://${bucket}/" . --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}"
-  fi
-
+  echo ":aws: :amazon-s3: sync ${cache_key}"
+  
+  bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
+  
+  aws s3 sync "s3://${bucket}/" . --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}"
+    
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -18,6 +18,7 @@ echo "Restoring cache $cache_key"
 bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/$cache_key"
 tmpdir=$(mktemp -d)
 # Set env var if we loaded the cache so we can skip reuploading it
-aws s3 cp "s3://${bucket}/cache.tar.gz" "$tmpdir/" && mark_restored "$cache_key" || echo "Cache not found"
-tar -xzf "$tmpdir/cache.tar.gz"
+aws s3 cp "s3://${bucket}/cache.tar.gz" "$tmpdir/" && \
+	tar -xzf "$tmpdir/cache.tar.gz" && \
+	mark_restored "$cache_key" || echo "Cache not found"
 rm -rf "$tmpdir"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,29 +1,23 @@
 #!/bin/bash
-# shellcheck disable=SC2001
 set -euo pipefail
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-if [[ "${BUILDKITE_PLUGIN_CACHE_DEBUG:-false}" =~ (true|on|1) ]] ; then
-  set -x
-fi
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+cache_key=$(get_cache_key)
 
-if [[ -n "${BUILDKITE_PLUGIN_CACHE_CACHE_KEY:-}" ]] ; then
+# Set an env var to include the cache key
+# This means we can skip re-uploading the same cache in the post_command
+function mark_restored() {
+  echo "Successfully restored $1"
+  export BUILDKITE_PLUGIN_CACHE_RESTORED=${BUILDKITE_PLUGIN_CACHE_RESTORED:-}:$1:
+}
 
-  cache_key_prefix=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/{.*//')
-  template_value=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/^[^\{{]*[^A-Za-z]*//' -e 's/.}}.*$//' | tr -d \' | tr -d \")
+echo "Restoring cache $cache_key"
 
-  if [[ $template_value == *"checksum"* ]]; then
-    checksum_argument=$(echo "$template_value" | sed -e 's/checksum*//')
-    function=${template_value/"checksum"/"shasum"}
-    result=$($function | tr -d "$checksum_argument")
-    cache_key="$cache_key_prefix$result"
-  else
-    cache_key=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
-  fi
-
-  echo ":aws: :amazon-s3: sync ${cache_key}"
-  
-  bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/${cache_key}"
-  
-  aws s3 sync "s3://${bucket}/" . --profile="${BUILDKITE_PLUGIN_CACHE_S3_PROFILE}"
-    
-fi
+bucket="${BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME}/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/$cache_key"
+tmpdir=$(mktemp -d)
+# Set env var if we loaded the cache so we can skip reuploading it
+aws s3 cp "s3://${bucket}/cache.tar.gz" "$tmpdir/" && mark_restored "$cache_key" || echo "Cache not found"
+tar -xzf "$tmpdir/cache.tar.gz"
+rm -rf "$tmpdir"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,0 +1,17 @@
+# shellcheck disable=SC2001
+# Gets the cache key from env vars and evaluates `checksum` commands
+# e.g. "v1-gemfile-{{ checksum Gemfile.lock }}" gets evaluated to "v1-gemfile-$(shasum Gemfile.lock)"
+function get_cache_key() {
+  cache_key_prefix=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/{.*//')
+  template_value=$(echo "$BUILDKITE_PLUGIN_CACHE_CACHE_KEY" | sed -e 's/^[^\{{]*[^A-Za-z]*//' -e 's/.}}.*$//' | tr -d \' | tr -d \")
+
+  if [[ $template_value == *"checksum"* ]]; then
+    checksum_argument=$(echo "$template_value" | sed -e 's/checksum*//')
+    function=${template_value/"checksum"/"shasum"}
+    result=$($function | tr -d "$checksum_argument")
+    cache_key="$cache_key_prefix$result"
+  else
+    cache_key=$BUILDKITE_PLUGIN_CACHE_CACHE_KEY
+  fi
+  echo "$cache_key"
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,5 +11,5 @@ configuration:
         type: [ string, array ]
     env:
       type: [ string, array ]
-      minimum: 2    
+      minimum: 2
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,13 +5,11 @@ requirements:
   - aws
 configuration:
   properties:
-    rsync_storage:
-      type: string
     cache_key:
-      type: string
+        type: string
     paths:
-      type: [ string, array ]
+        type: [ string, array ]
     env:
       type: [ string, array ]
-      minimum: 2
+      minimum: 2    
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -6,48 +6,111 @@ load "$BATS_PATH/load.bash"
 # export GIT_STUB_DEBUG=/dev/tty
 
 @test "Pre-command restores cache with basic key" {
-  
-  stub aws \
-   "aws s3 sync s3://my-bucket/my-org/my-pipeline/v1-cache-key/ . : echo sync cache"
-  
-  
+  stub aws '* : echo aws $@'
+  stub tar '* : echo tar $@'
+
   export BUILDKITE_ORGANIZATION_SLUG="my-org"
   export BUILDKITE_PIPELINE_SLUG="my-pipeline"
   export BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME="my-bucket"
   export BUILDKITE_PLUGIN_CACHE_S3_PROFILE="my-profile"
   export BUILDKITE_PLUGIN_CACHE_CACHE_KEY="v1-cache-key"
   run "$PWD/hooks/pre-command"
-  
+
   assert_success
-  assert_output --partial "sync v1-cache-key"
-  
-  unset BUILDKITE_PLUGIN_CACHE_CACHE_KEY  
+  assert_output --partial "aws s3 cp s3://my-bucket/my-org/my-pipeline/v1-cache-key/cache.tar.gz /tmp"
+  assert_output --regexp "tar -xzf .*/cache.tar.gz"
+
+  unset BUILDKITE_PLUGIN_CACHE_CACHE_KEY
   unset BUILDKITE_PLUGIN_CACHE_S3_PROFILE
   unset BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
 }
 
-@test "Post-command syncs artifacts with a single path" {
+@test "Post-command syncs artifacts" {
+  stub aws '* : echo aws $@'
+  # hacky way to unstub as unstub doesn't work
+  stub tar '* : busybox tar $@ && ls $2'
 
-  stub aws \
-   "aws s3 sync Pods s3://my-bucket/my-org/my-pipeline/v1-cache-key/Pods : echo sync Pods"
-
+  export BUILDKITE_COMMAND_EXIT_STATUS=0
+  export BUILDKITE_PLUGIN_CACHE_DEBUG=true
   export BUILDKITE_ORGANIZATION_SLUG="my-org"
   export BUILDKITE_PIPELINE_SLUG="my-pipeline"
   export BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME="my-bucket"
   export BUILDKITE_PLUGIN_CACHE_S3_PROFILE="my-profile"
   export BUILDKITE_PLUGIN_CACHE_CACHE_KEY="v1-cache-key"
-  export BUILDKITE_PLUGIN_CACHE_PATHS="Pods"
+  export BUILDKITE_PLUGIN_CACHE_PATHS_0="hooks"
+  export BUILDKITE_PLUGIN_CACHE_PATHS_1="tests"
   run "$PWD/hooks/post-command"
 
   assert_success
-  assert_output --partial "sync Pods"
+  assert_output --partial "Compressing cache for v1-cache-key"
+  assert_output --regexp "/tmp/.*/cache.tar.gz"
+  assert_output --regexp "aws s3 cp .* s3://my-bucket/my-org/my-pipeline/v1-cache-key/cache.tar.gz"
 
-  unset BUILDKITE_PLUGIN_CACHE_PATHS
-  unset BUILDKITE_PLUGIN_CACHE_CACHE_KEY  
+  unset BUILDKITE_PLUGIN_CACHE_PATHS_1
+  unset BUILDKITE_PLUGIN_CACHE_PATHS_0
+  unset BUILDKITE_PLUGIN_CACHE_CACHE_KEY
   unset BUILDKITE_PLUGIN_CACHE_S3_PROFILE
   unset BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_ORGANIZATION_SLUG
+  unset BUILDKITE_COMMAND_EXIT_STATUS
 }
+
+@test "Post-command skips uploading if cache was restored" {
+  stub aws '* : echo aws $@'
+
+  export BUILDKITE_COMMAND_EXIT_STATUS=0
+  export BUILDKITE_ORGANIZATION_SLUG="my-org"
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+  export BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME="my-bucket"
+  export BUILDKITE_PLUGIN_CACHE_S3_PROFILE="my-profile"
+  export BUILDKITE_PLUGIN_CACHE_CACHE_KEY="v1-cache-key"
+  export BUILDKITE_PLUGIN_CACHE_RESTORED=":v1-cache-key:"
+  export BUILDKITE_PLUGIN_CACHE_PATHS_0="Pods"
+  export BUILDKITE_PLUGIN_CACHE_PATHS_1="Things"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Not uploading new cache - it was restored"
+
+  unset BUILDKITE_PLUGIN_CACHE_PATHS_1
+  unset BUILDKITE_PLUGIN_CACHE_PATHS_0
+  unset BUILDKITE_PLUGIN_CACHE_RESTORED
+  unset BUILDKITE_PLUGIN_CACHE_CACHE_KEY
+  unset BUILDKITE_PLUGIN_CACHE_S3_PROFILE
+  unset BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME
+  unset BUILDKITE_PIPELINE_SLUG
+  unset BUILDKITE_ORGANIZATION_SLUG
+  unset BUILDKITE_COMMAND_EXIT_STATUS
+}
+
+@test "Post-command skips uploading if command errored" {
+  stub aws '* : echo aws $@'
+
+  export BUILDKITE_COMMAND_EXIT_STATUS=1
+  export BUILDKITE_ORGANIZATION_SLUG="my-org"
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+  export BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME="my-bucket"
+  export BUILDKITE_PLUGIN_CACHE_S3_PROFILE="my-profile"
+  export BUILDKITE_PLUGIN_CACHE_CACHE_KEY="v1-cache-key"
+  export BUILDKITE_PLUGIN_CACHE_RESTORED=":v1-cache-key:"
+  export BUILDKITE_PLUGIN_CACHE_PATHS_0="Pods"
+  export BUILDKITE_PLUGIN_CACHE_PATHS_1="Things"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Command failed, not uploading cache"
+
+  unset BUILDKITE_PLUGIN_CACHE_PATHS_1
+  unset BUILDKITE_PLUGIN_CACHE_PATHS_0
+  unset BUILDKITE_PLUGIN_CACHE_RESTORED
+  unset BUILDKITE_PLUGIN_CACHE_CACHE_KEY
+  unset BUILDKITE_PLUGIN_CACHE_S3_PROFILE
+  unset BUILDKITE_PLUGIN_CACHE_S3_BUCKET_NAME
+  unset BUILDKITE_PIPELINE_SLUG
+  unset BUILDKITE_ORGANIZATION_SLUG
+  unset BUILDKITE_COMMAND_EXIT_STATUS
+}
+


### PR DESCRIPTION
There are 2 major changes in this PR:

1. Removes rsync support - this is a pretty niche use-case that adds a lot
   of complication to the code. It's probably better off as a separate plugin

2. tar.gz files before uploading to S3. This saves a lot of time for most
   caches, especially `node_modules` (this was the motivation behind the
   rsync implementation in the first place)

I also did a lot of refactoring, added and fixed tests and shellcheck